### PR TITLE
Bump testing Logstash from 6 to 8

### DIFF
--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        logstashversion: [6, 7]
+        logstashversion: [7, 8]
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Logstash versions shouldn't make much difference when testing syntax. But, hey, why not.