### PR TITLE
Add option to actions to run in queue, too

### DIFF
--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
We need this to have forced checks run in the merge queue. Otherwise GitHub is waiting until the timeout and then fails the merge.